### PR TITLE
Add support for turbo drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# Livewire Turbolinks Plugin
+# Livewire Turbolinks/Turbo Plugin
 
-If you are using Turbolinks AND Livewire on the same page, this plugin is required.
+If you are using Turbolinks/Turbo AND Livewire on the same page, this plugin is required.
 
 Livewire Version 1 supported Turbolinks internally. Livewire Version 2 has removed internal support and extracted it into this plugin.
 
-The goal of this adapter is to provide full Turbolinks support in Livewire. However, because certain current and future features may be incompatible, we've extracted this into a seperate package with the goal of keeping Turbolinks expectations, bugs, and fixes, isolated and away from the core of Livewire.
+The goal of this adapter is to provide full Turbolinks/Turbo support in Livewire. However, because certain current and future features may be incompatible, we've extracted this into a separate package with the goal of keeping Turbolinks expectations, bugs, and fixes, isolated and away from the core of Livewire.
 
 To that end, there are loose plans to add a Turbolinks-esque set of functionality to Livewire itself, but there are no immediate plans.
 
 For the forseeable future, this adapter will remain a valid option for Livewire users hoping to user Turbolinks in their apps.
 
 ## Livewire Version Support
-(Livewire version 1.x suports Turbolinks out of the box)
+(Livewire version 1.x supports Turbolinks out of the box)
 
-Livewire Version | Turbolinks Plugin Version
+Livewire Version | Turbolinks/Turbo Plugin Version
 --- | ---
 2.x | 0.1.x
 
@@ -21,11 +21,11 @@ Livewire Version | Turbolinks Plugin Version
 ### CDN
 Include the CDN asset after `@livewireScripts` or  `<livewire:scripts>` in your app's HTML:
 
-> Note: You MUST have the `data-turbolinks-eval="false"` added to the script tag.
+> Note: You MUST have either the `data-turbolinks-eval="false"` or `data-turbo-eval="false"` attributes added to the script tag (having both won't hurt).
 
 ```html
     ...
     @livewireScripts
-    <script src="https://cdn.jsdelivr.net/gh/livewire/turbolinks@v0.1.x/dist/livewire-turbolinks.js" data-turbolinks-eval="false"></script>
+    <script src="https://cdn.jsdelivr.net/gh/livewire/turbolinks@v0.1.x/dist/livewire-turbolinks.js" data-turbolinks-eval="false" data-turbo-eval="false"></script>
 </body>
 ```

--- a/dist/livewire-turbolinks.js
+++ b/dist/livewire-turbolinks.js
@@ -8,7 +8,8 @@
     }
 
     var firstTime = true;
-    document.addEventListener("turbolinks:load", function () {
+
+    function wireTurboAfterFirstVisit() {
       // We only want this handler to run AFTER the first load.
       if (firstTime) {
         firstTime = false;
@@ -16,8 +17,9 @@
       }
 
       window.Livewire.restart();
-    });
-    document.addEventListener("turbolinks:before-cache", function () {
+    }
+
+    function wireTurboBeforeCache() {
       document.querySelectorAll('[wire\\:id]').forEach(function (el) {
         const component = el.__livewire;
         const dataObject = {
@@ -27,7 +29,12 @@
         };
         el.setAttribute('wire:initial-data', JSON.stringify(dataObject));
       });
-    });
+    }
+
+    document.addEventListener("turbo:load", wireTurboAfterFirstVisit);
+    document.addEventListener("turbo:before-cache", wireTurboBeforeCache);
+    document.addEventListener("turbolinks:load", wireTurboAfterFirstVisit);
+    document.addEventListener("turbolinks:before-cache", wireTurboBeforeCache);
     Livewire.hook('beforePushState', state => {
       if (!state.turbolinks) state.turbolinks = {};
     });

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,8 @@ if (typeof window.livewire === 'undefined') {
 }
 
 var firstTime = true
-document.addEventListener("turbolinks:load", function() {
+
+function wireTurboAfterFirstVisit () {
     // We only want this handler to run AFTER the first load.
     if  (firstTime) {
         firstTime = false
@@ -12,9 +13,9 @@ document.addEventListener("turbolinks:load", function() {
     }
 
     window.Livewire.restart()
-})
+}
 
-document.addEventListener("turbolinks:before-cache", function() {
+function wireTurboBeforeCache() {
     document.querySelectorAll('[wire\\:id]').forEach(function(el) {
         const component = el.__livewire;
         const dataObject = {
@@ -24,7 +25,13 @@ document.addEventListener("turbolinks:before-cache", function() {
         };
         el.setAttribute('wire:initial-data', JSON.stringify(dataObject));
     });
-});
+}
+
+document.addEventListener("turbo:load", wireTurboAfterFirstVisit)
+document.addEventListener("turbo:before-cache", wireTurboBeforeCache);
+
+document.addEventListener("turbolinks:load", wireTurboAfterFirstVisit)
+document.addEventListener("turbolinks:before-cache", wireTurboBeforeCache);
 
 Livewire.hook('beforePushState', (state) => {
     if (! state.turbolinks) state.turbolinks = {}


### PR DESCRIPTION
### Added

- Adds support for the new Turbo Drive so we can combine Hotwire and Livewire on the same page (see [Turbo Drive documentation](https://turbo.hotwire.dev/handbook/building#working-with-script-elements) about the latest new `data-turbo-eval="false"`)

### Changed

- Tweaked the documentation (README) a bit

---

Not sure if I should just fork it and keep supporting it separately or if you want this to be on the same plugin.